### PR TITLE
Update ROS 2 build workflow

### DIFF
--- a/.github/workflows/buildTest.yml
+++ b/.github/workflows/buildTest.yml
@@ -1,69 +1,57 @@
 name: Build-Test
-# Run this workflow every time a new commit pushed to your repository
+
 on: push
 
 jobs:
-  # Set the job key. The key is displayed as the job name
-  # when a job name is not provided
   build-test:
-    # Name the Job
     name: Build test
-    # Set the type of machine to run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-      # Run package update
-      - name: Run package update
-        run: |
-          sudo apt-get update
-          sudo apt-get dist-upgrade -y
-
-      # Install ROS Melodic
-      - name: Install ROS Noetic
-        run: |
-          sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-          sudo apt install curl
-          curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
-          sudo apt-get update
-          sudo apt-get install ros-noetic-desktop python3-rosdep python3-rosinstall python3-rosinstall-generator python3-wstool build-essential
-          sudo rosdep init
-          rosdep update
-
-      # Install dependencies
-      - name: Install dependencies
-        run: |
-          sudo apt-get install git libgflags-dev libpopt-dev libgoogle-glog-dev liblua5.1-0-dev libboost-all-dev libqt5websockets5-dev
-
-
-      # Checks out a copy of your repository
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
-          submodules: 'recursive'
+          submodules: recursive
 
-      # Checkout and build amrl_msgs
-      - name: Get amrl_msgs
+      - name: Setup ROS 2 Humble
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: humble
+
+      - name: Install system dependencies
         run: |
-          source /opt/ros/melodic/setup.bash
-          export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:$GITHUB_WORKSPACE:$GITHUB_WORKSPACE/../amrl_msgs
-          cd $GITHUB_WORKSPACE/..
-          git clone https://github.com/ut-amrl/amrl_msgs.git
-          cd amrl_msgs
-          make
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgoogle-glog-dev \
+            libgflags-dev \
+            liblua5.1-0-dev \
+            libqt5websockets5-dev \
+            libqt5opengl5-dev \
+            qtbase5-dev \
+            libboost-all-dev \
+            python3-colcon-common-extensions \
+            python3-rosdep
 
-
-      # Checkout and build amrl_maps
-      - name: Get amrl_maps
+      - name: Prepare workspace
         run: |
-          source /opt/ros/melodic/setup.bash
-          export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:$GITHUB_WORKSPACE:$GITHUB_WORKSPACE/../amrl_maps
-          cd $GITHUB_WORKSPACE/..
-          git clone https://github.com/ut-amrl/amrl_maps.git
+          mkdir -p $HOME/ros2_ws/src
+          ln -s $GITHUB_WORKSPACE $HOME/ros2_ws/src/ut_automata
+          cd $HOME/ros2_ws/src
+          if ! git clone --depth 1 --branch ros2 --single-branch https://github.com/ut-amrl/amrl_msgs.git; then
+            git clone --depth 1 https://github.com/ut-amrl/amrl_msgs.git
+          fi
+          if ! git clone --depth 1 --branch ros2 --single-branch https://github.com/ut-amrl/amrl_maps.git; then
+            git clone --depth 1 https://github.com/ut-amrl/amrl_maps.git
+          fi
 
-      # Compiles the code
-      - name: Run build
+      - name: Install ROS 2 package dependencies
         run: |
-          source /opt/ros/melodic/setup.bash
-          export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:$GITHUB_WORKSPACE:$GITHUB_WORKSPACE/../amrl_msgs:$GITHUB_WORKSPACE/../amrl_maps
-          cd $GITHUB_WORKSPACE
-          make
+          source /opt/ros/humble/setup.bash
+          sudo rosdep init || true
+          rosdep update
+          rosdep install --from-paths $HOME/ros2_ws/src --ignore-src --rosdistro humble -y
+
+      - name: Build workspace
+        run: |
+          source /opt/ros/humble/setup.bash
+          colcon build --workspace $HOME/ros2_ws --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_MODE=Simulation


### PR DESCRIPTION
## Summary
- update the Build-Test workflow to run on Ubuntu 22.04 with ROS 2 Humble
- install required ROS 2 system dependencies and fetch the ROS 2 branches of amrl repositories
- build the workspace with colcon using the ROS 2 environment

## Testing
- Not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68fa6149b030832395d51395a43f6ce5